### PR TITLE
linux: fix KERNEL_MODULE_AUTOLOAD variable ignored

### DIFF
--- a/recipes-kernel/linux/linux-compulab_5.15.32.bb
+++ b/recipes-kernel/linux/linux-compulab_5.15.32.bb
@@ -69,6 +69,4 @@ FILES:linux-compulab-headers = "${exec_prefix}/src/linux*"
 
 KERNEL_SPLIT_MODULES = "0"
 
-FILES:${KERNEL_PACKAGE_NAME}-modules = "/lib/modules/ /etc/"
-
 COMPATIBLE_MACHINE = "(ucm-imx8mm|iot-gate-imx8)"

--- a/recipes-kernel/linux/linux-compulab_5.15.32.bb
+++ b/recipes-kernel/linux/linux-compulab_5.15.32.bb
@@ -67,7 +67,7 @@ do_kernel_localversion:prepend() {
 PACKAGES =+ "linux-compulab-headers"
 FILES:linux-compulab-headers = "${exec_prefix}/src/linux*"
 
-PACKAGESPLITFUNCS:remove = "split_kernel_module_packages"
+KERNEL_SPLIT_MODULES = "0"
 
 FILES:${KERNEL_PACKAGE_NAME}-modules = "/lib/modules/ /etc/"
 


### PR DESCRIPTION
fix: https://github.com/compulab-yokneam/meta-bsp-imx8mm/issues/30
Replacing PACKAGESPLITFUNCS:prepend = "split_kernel_module_packages " by KERNEL_SPLIT_MODULES = "0" allow to keep one kernel package with all the modules (for performance) but  don't ignore KERNEL_MODULE_AUTOLOAD variable.
