### PR TITLE
linux-compulab: fix defconfig generation

### DIFF
--- a/recipes-kernel/linux/linux-compulab.main
+++ b/recipes-kernel/linux/linux-compulab.main
@@ -38,11 +38,26 @@ KERNEL_VERSION_SANITY_SKIP="1"
 # Merged from the bbappend
 FILESEXTRAPATHS:prepend := "${THISDIR}/compulab/${PV}/imx8mm:"
 
-LINUX_VERSION_EXTENSION = "-${CL_RELEASE}"
+KBUILD_DEFCONFIG:iot-gate-imx8 = "cl-imx8m-mini_defconfig"
+DELTA_KERNEL_DEFCONFIG = "${MACHINE}.config"
 
-do_configure() {
-    oe_runmake cl-imx8m-mini_defconfig ${MACHINE}.config ${KBUILD_DEFCONFIG_EXTRA_FRAGMENTS}
+do_merge_delta_config() {
+    # create config with make config
+    oe_runmake  -C ${S} O=${B} ${KERNEL_DEFCONFIG}
+
+    # add config fragments
+    for deltacfg in ${DELTA_KERNEL_DEFCONFIG}; do
+        if [ -f ${S}/arch/${ARCH}/configs/${deltacfg} ]; then
+            oe_runmake  -C ${S} O=${B} ${deltacfg}
+        elif [ -f "${WORKDIR}/${deltacfg}" ]; then
+            ${S}/scripts/kconfig/merge_config.sh -m .config ${WORKDIR}/${deltacfg}
+        elif [ -f "${deltacfg}" ]; then
+            ${S}/scripts/kconfig/merge_config.sh -m .config ${deltacfg}
+        fi
+    done
+    cp .config ${WORKDIR}/defconfig
 }
+addtask merge_delta_config before do_kernel_localversion after do_patch
 
 do_compile:prepend() {
     export SOURCE_DATE_EPOCH=$(date +%s)
@@ -90,10 +105,6 @@ do_install:append() {
 }
 
 FILES:${KERNEL_PACKAGE_NAME}-image:append = " /boot/kernel-${KERNEL_VERSION} /boot/config-${KERNEL_VERSION} "
-
-do_kernel_localversion:prepend() {
-    touch ${WORKDIR}/defconfig
-}
 
 PACKAGES =+ "linux-compulab-headers"
 FILES:linux-compulab-headers = "${exec_prefix}/src/linux*"


### PR DESCRIPTION
Before this change the default feature of adding kernel defconfig
fragments in form of .cfg / .scc was broken because do_configure would
call make to generate a .config out of a defconfig and a single fragment
in-tree, completely disregarding all the workd done by
kernel-yocto.bbclass

To fix this we merge the in-tree defconfig with the in-tree fragments
using do_merge_delta_config task (copied from meta-freescale) and save
that as defconfig in ${WORKDIR}. kernel-yocto will then take this file
as a defconfig base and apply any fragments specified in SRC_URI.

This fixes the previously two fragments not being used (
linux-firmware-sdma.cfg, linux-headers.cfg).

Also, don't set LINUX_VERSION_EXTENSION. The in-tree fragment already
sets CONFIG_LOCALVERSION="-iot-gate-imx8m-4.0.0", this would just
overwrite it with "-4.0" which I don't think was desired.
